### PR TITLE
Adapt to latest Manifestival (>0.1.0) Client API

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -78,15 +78,16 @@
   revision = "ab8a2e0c74be"
 
 [[projects]]
-  digest = "1:4d67892f272491cc3a7c9bcafa8baeee5af178060a541c304def117c017d5eec"
+  branch = "master"
+  digest = "1:8b75952005c5cebad031813b05de9e414a8668d94b9bc03bd79ab55920b35ded"
   name = "github.com/manifestival/manifestival"
   packages = [
     ".",
     "patch",
+    "sources",
   ]
   pruneopts = "UT"
-  revision = "f5dd205675d3301a65eeb90aa4c7f793b8c0897f"
-  version = "v0.1.0"
+  revision = "fdc4c39040554b4f266672834b4b754d40808210"
 
 [[projects]]
   digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
@@ -397,6 +398,7 @@
     "github.com/manifestival/manifestival",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
+    "k8s.io/apimachinery/pkg/types",
     "sigs.k8s.io/controller-runtime/pkg/client",
   ]
   solver-name = "gps-cdcl"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/manifestival/manifestival"
-  version = "0.1.0"
+  branch = "master"
 
 [[constraint]]
   name = "k8s.io/apimachinery"

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,93 @@
+package client
+
+import (
+	"reflect"
+	"testing"
+
+	mf "github.com/manifestival/manifestival"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const owner = "manifestival"
+
+func TestCreateOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		options  []mf.ApplyOption
+		expected []client.CreateOption
+	}{{
+		name:     "Manager w/DryRun",
+		options:  []mf.ApplyOption{mf.DryRunAll, mf.FieldManager(owner)},
+		expected: []client.CreateOption{client.DryRunAll, client.FieldOwner(owner)},
+	}, {
+		name:     "Manager",
+		options:  []mf.ApplyOption{mf.FieldManager(owner)},
+		expected: []client.CreateOption{client.FieldOwner(owner)},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := createWith(test.options)
+			if !reflect.DeepEqual(actual, test.expected) {
+				t.Errorf("wanted %v, got %v", test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestUpdateOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		options  []mf.ApplyOption
+		expected []client.UpdateOption
+	}{{
+		name:     "Manager w/DryRun",
+		options:  []mf.ApplyOption{mf.DryRunAll, mf.FieldManager(owner)},
+		expected: []client.UpdateOption{client.DryRunAll, client.FieldOwner(owner)},
+	}, {
+		name:     "Manager",
+		options:  []mf.ApplyOption{mf.FieldManager(owner)},
+		expected: []client.UpdateOption{client.FieldOwner(owner)},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := updateWith(test.options)
+			if !reflect.DeepEqual(actual, test.expected) {
+				t.Errorf("wanted %v, got %v", test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestDeleteOptions(t *testing.T) {
+	uid := types.UID("test")
+	tests := []struct {
+		name     string
+		options  []mf.DeleteOption
+		expected []client.DeleteOption
+	}{{
+		name:     "GracePeriodSeconds",
+		options:  []mf.DeleteOption{mf.DryRunAll, mf.GracePeriodSeconds(5), mf.IgnoreNotFound(false)},
+		expected: []client.DeleteOption{client.DryRunAll, client.GracePeriodSeconds(5)},
+	}, {
+		name:     "Preconditions",
+		options:  []mf.DeleteOption{mf.Preconditions(metav1.Preconditions{UID: &uid})},
+		expected: []client.DeleteOption{client.Preconditions(metav1.Preconditions{UID: &uid})},
+	}, {
+		name:     "PropagationPolicy",
+		options:  []mf.DeleteOption{mf.PropagationPolicy(metav1.DeletePropagationOrphan)},
+		expected: []client.DeleteOption{client.PropagationPolicy(metav1.DeletePropagationOrphan)},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := deleteWith(test.options)
+			if !reflect.DeepEqual(actual, test.expected) {
+				t.Errorf("wanted %v, got %v", test.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Main advantage is pushing the IgnoreNotFound option to the Client impls.